### PR TITLE
Set timeout in client to be the same as in server, 1 hour

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v17
+    - uses: cachix/install-nix-action@v20
       with:
         install_url: ${{ matrix.install_url }}
-    - uses: cachix/cachix-action@v10
+    - uses: cachix/cachix-action@v12
       with:
         name: sourmash-bio
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -142,7 +142,9 @@ fn main() -> Result<()> {
     }
 
     info!("Sending request to https://mastiff.sourmash.bio");
-    let client = reqwest::blocking::Client::new();
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(3600))
+        .build()?;
     let res = client
         .post("https://mastiff.sourmash.bio/search")
         .body(sig_data)


### PR DESCRIPTION
Some queries might take longer than the default timeout (30s) to run, even if the server is still calculating the answer. This will keep both in sync (1h is a long time, but...)