### PR TITLE
ci: release please fixes, take 2

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           command: manifest
           release-type: rust
+          package-name: mastiff-client
 
       - uses: actions/checkout@v2
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Still trying to fix release please, now adding `package-name` because it is a monorepo.