### PR TITLE
ci: move package-name into config for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           command: manifest
           release-type: rust
-          package-name: mastiff-client
 
       - uses: actions/checkout@v2
         if: ${{ steps.release.outputs.release_created }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "bootstrap-sha": "bbfef0d7674e429391527e54256ec1993129b1b1",
   "packages": {
     ".": {
+      "package-name": "mastiff-client",
       "changelog-path": "CHANGELOG.md",
       "release-type": "rust",
       "release-as": "0.1.0",


### PR DESCRIPTION
Since the `manifest` command is being used, config should be in the manifest.