### PR TITLE
feat: Import rocksdb-eval as mastiff-index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,7 +3008,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand",
  "static_assertions",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,16 +544,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
+checksum = "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed"
 dependencies = [
  "libc",
 ]
@@ -1988,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
 dependencies = [
  "either",
  "rayon-core",
@@ -1998,14 +1988,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
@@ -2578,12 +2566,11 @@ dependencies = [
  "histogram",
  "log",
  "md5",
- "memmap2 0.7.1",
+ "memmap2 0.8.0",
  "murmurhash3",
  "niffler",
  "nohash-hasher",
  "num-iter",
- "numsep",
  "once_cell",
  "ouroboros",
  "piz",
@@ -2594,7 +2581,6 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_json",
- "size",
  "thiserror",
  "twox-hash",
  "typed-builder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1209,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2453,9 +2453,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -2550,10 +2550,10 @@ checksum = "c361f1b577b7528df46d04ee4d800a2fb4eafd44f187940789e8ab7fd378b509"
 [[package]]
 name = "sourmash"
 version = "0.12.0"
-source = "git+https://github.com/sourmash-bio/sourmash?branch=lirber/mastiff#a4949b096f6f59210e3e9d6283ce696342a82e8c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760c7b049cc70294122c44c4e6d0922ed0e79a8e04f2d739b98a982027a9fd4a"
 dependencies = [
  "az",
- "bytecount",
  "byteorder",
  "camino",
  "cfg-if 1.0.0",
@@ -2995,7 +2995,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand",
  "static_assertions",
 ]
@@ -3168,9 +3168,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3180,9 +3180,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
 dependencies = [
  "bumpalo",
  "log",
@@ -3207,9 +3207,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3217,9 +3217,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3230,15 +3230,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "bytecount"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
+checksum = "d1a12477b7237a01c11a80a51278165f9ba0edd28fa6db00a65ab230320dc58c"
 
 [[package]]
 name = "bytemuck"
@@ -339,9 +339,9 @@ checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -1423,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed"
+checksum = "deaba38d7abf1d4cca21cc89e932e542ba2b9258664d2a9ef0e61512039c9375"
 dependencies = [
  "libc",
 ]
@@ -2550,6 +2550,7 @@ checksum = "c361f1b577b7528df46d04ee4d800a2fb4eafd44f187940789e8ab7fd378b509"
 [[package]]
 name = "sourmash"
 version = "0.12.0"
+source = "git+https://github.com/sourmash-bio/sourmash?branch=lirber/mastiff#a4949b096f6f59210e3e9d6283ce696342a82e8c"
 dependencies = [
  "az",
  "bytecount",
@@ -2566,7 +2567,7 @@ dependencies = [
  "histogram",
  "log",
  "md5",
- "memmap2 0.8.0",
+ "memmap2 0.9.0",
  "murmurhash3",
  "niffler",
  "nohash-hasher",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-
-[[package]]
 name = "addr2line"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +59,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,7 +107,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -209,6 +209,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
+name = "binary-merge"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab"
+
+[[package]]
 name = "bindgen"
 version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,7 +232,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.15",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -234,6 +240,18 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "brotli"
@@ -287,9 +305,9 @@ checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13fe11640a23eb24562225322cd3e452b93a3d4091d62fab69c70542fcd17d1f"
+checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
@@ -298,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31225543cb46f81a7e224762764f4a6a0f097b1db0b175f69e8065efaa42de5"
+checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -353,6 +371,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,17 +411,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
- "time 0.1.45",
  "wasm-bindgen",
- "winapi",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -540,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.14"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
@@ -553,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -605,7 +631,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.15",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -622,7 +648,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -637,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "encoding_rs"
@@ -648,6 +674,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f33313078bb8d4d05a2733a94ac4c2d8a0df9a2b84424ebf4f33bfc224a890e"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -732,19 +770,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "flume"
-version = "0.10.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "pin-project",
- "spin 0.9.8",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,6 +783,12 @@ checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
@@ -844,7 +875,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -1108,6 +1139,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inplace-vec-builder"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf64c2edc8226891a71f127587a2861b132d2b942310843814d5001d99a1d307"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,6 +1172,15 @@ name = "ipnet"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1170,9 +1219,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1191,9 +1240,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"
@@ -1207,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.6.3+6.28.2"
+version = "0.11.0+8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "184ce2a189a817be2731070775ad053b6804a340fee05c6686d711db27455917"
+checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -1217,14 +1266,15 @@ dependencies = [
  "glob",
  "libc",
  "libz-sys",
+ "lz4-sys",
  "zstd-sys",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.1.9"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ee889ecc9568871456d42f603d6a0ce59ff328d291063a45cbdf0036baf6db"
+checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1258,11 +1308,18 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "lz4-sys"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
 dependencies = [
- "cfg-if 1.0.0",
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -1305,6 +1362,7 @@ dependencies = [
 name = "mastiff-index"
 version = "0.1.0"
 dependencies = [
+ "camino",
  "clap",
  "env_logger",
  "histogram",
@@ -1374,10 +1432,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.8.0"
+name = "memmap2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
@@ -1430,7 +1497,7 @@ checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.45.0",
 ]
 
@@ -1457,15 +1524,6 @@ name = "murmurhash3"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2983372caf4480544083767bf2d27defafe32af49ab4df3a0b7fc90793a3664"
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "needletail"
@@ -1609,9 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "os_info"
@@ -1632,25 +1690,27 @@ checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "ouroboros"
-version = "0.15.6"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1358bd1558bd2a083fed428ffeda486fbfb323e698cdda7794259d592ca72db"
+checksum = "1c86de06555b970aec45229b27291b53154f21a5743a163419f4e4c0b065dcde"
 dependencies = [
  "aliasable",
  "ouroboros_macro",
+ "static_assertions",
 ]
 
 [[package]]
 name = "ouroboros_macro"
-version = "0.15.6"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
+checksum = "8cad0c4b129e9696e37cb712b243777b90ef489a0bfaa0ac34e7d9b860e4f134"
 dependencies = [
- "Inflector",
+ "heck",
+ "itertools",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1751,17 +1811,18 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piz"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c75d1c00e6d407e283cc66d9d4fd0985ef1703c761520845b93c4f981bfb65"
+checksum = "898b071c1938a2c92b95c18708cbf38f2566a01f0ab9dd7bdf4329987e5c2e17"
 dependencies = [
+ "camino",
  "chrono",
  "codepage-437",
  "crc32fast",
  "flate2",
  "log",
+ "memchr",
  "thiserror",
- "twoway",
 ]
 
 [[package]]
@@ -1798,12 +1859,12 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.4"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ceca8aaf45b5c46ec7ed39fff75f57290368c1846d33d24a122ca81416ab058"
+checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
 dependencies = [
  "proc-macro2",
- "syn 2.0.15",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1841,9 +1902,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1882,12 +1943,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2041,9 +2108,9 @@ dependencies = [
 
 [[package]]
 name = "retain_mut"
-version = "0.1.9"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
+checksum = "8c31b5c4033f8fdde8700e4657be2c497e7288f01515be52168c631e2e4d4086"
 
 [[package]]
 name = "ring"
@@ -2062,23 +2129,26 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.41"
+version = "0.7.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21499ed91807f07ae081880aabb2ccc0235e9d88011867d984525e9a4c3cfa3e"
+checksum = "0200c8230b013893c0b2d6213d6ec64ed2b9be2e0e016682b7224ff82cff5c58"
 dependencies = [
+ "bitvec",
  "bytecheck",
  "hashbrown",
  "ptr_meta",
  "rend",
  "rkyv_derive",
  "seahash",
+ "tinyvec",
+ "uuid 1.3.2",
 ]
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.41"
+version = "0.7.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1c672430eb41556291981f45ca900a0239ad007242d1cb4b4167af842db666"
+checksum = "b2e06b915b5c230a17d7a736d1e2e63ee753c256a8614ef3f5147b13a4f5541d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2087,9 +2157,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd539cab4e32019956fe7e0cf160bb6d4802f4be2b52c4253d76d3bb0f85a5f7"
+checksum = "6106b5cf8587f5834158895e9715a3c6c9716c8aefab57f1f7680917191c7873"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -2098,9 +2168,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.18.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620f4129485ff1a7128d184bc687470c21c7951b64779ebc9cfdad3dcd920290"
+checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -2368,36 +2438,36 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.20",
+ "time",
  "url",
  "uuid 1.3.2",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
@@ -2492,21 +2562,23 @@ checksum = "c361f1b577b7528df46d04ee4d800a2fb4eafd44f187940789e8ab7fd378b509"
 [[package]]
 name = "sourmash"
 version = "0.12.0"
-source = "git+https://github.com/sourmash-bio/sourmash?tag=mastiff_roaring#2819307a768469ed8d6bd15f8e17889edfcf81b6"
 dependencies = [
  "az",
  "bytecount",
  "byteorder",
+ "camino",
  "cfg-if 1.0.0",
+ "chrono",
  "counter",
  "csv",
+ "enum_dispatch",
  "fixedbitset",
- "flume",
+ "getrandom",
  "getset",
  "histogram",
  "log",
  "md5",
- "memmap2",
+ "memmap2 0.7.1",
  "murmurhash3",
  "niffler",
  "nohash-hasher",
@@ -2542,9 +2614,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "stable_deref_trait"
@@ -2571,7 +2640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b55cdc318ede251d0957f07afe5fed912119b8c1bc5a7804151826db999e737"
 dependencies = [
  "debugid",
- "memmap2",
+ "memmap2 0.5.10",
  "stable_deref_trait",
  "uuid 1.3.2",
 ]
@@ -2599,9 +2668,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2623,6 +2692,12 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -2669,7 +2744,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2680,17 +2755,6 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -2762,7 +2826,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2867,7 +2931,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2939,31 +3003,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
-name = "twoway"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c57ffb460d7c24cd6eda43694110189030a3d1dfe418416d9468fd1c1d290b47"
-dependencies = [
- "memchr",
- "unchecked-index",
-]
-
-[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand",
  "static_assertions",
 ]
 
 [[package]]
 name = "typed-builder"
-version = "0.10.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89851716b67b937e393b3daa8423e67ddfc4bbbf1654bcf05488e95e0828db0c"
+checksum = "64cba322cb9b7bc6ca048de49e83918223f35e7a86311267013afff257004870"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2984,12 +3038,6 @@ checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "unchecked-index"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeba86d422ce181a719445e51872fa30f1f7413b62becb52e95ec91aa262d85c"
 
 [[package]]
 name = "unicase"
@@ -3090,10 +3138,13 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec-collections"
-version = "0.3.6"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2390c4dc8ae8640c57d067b1a3d40bc05c124cc6bc7394d761b53435d41b76"
+checksum = "3c9965c8f2ffed1dbcd16cafe18a009642f540fa22661c6cfd6309ddb02e4982"
 dependencies = [
+ "binary-merge",
+ "inplace-vec-builder",
+ "lazy_static",
  "num-traits",
  "serde",
  "smallvec",
@@ -3124,21 +3175,15 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3148,16 +3193,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
 
@@ -3175,9 +3220,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3185,28 +3230,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3413,6 +3458,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "xz2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3423,10 +3477,11 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.6.3+zstd.1.5.2"
+version = "2.0.8+zstd.1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
+checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
 dependencies = [
  "cc",
  "libc",
+ "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,6 +1302,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mastiff-index"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "env_logger",
+ "histogram",
+ "log",
+ "numsep",
+ "size",
+ "sourmash",
+]
+
+[[package]]
 name = "mastiff-server"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,7 @@ niffler = { version = "2.4.0", default-features = false, features = [ "gz" ]}
 numsep = "0.1.12"
 reqwest = { version = "0.11.11", default-features = false, features = [ "blocking", "rustls-tls" ] }
 size = "0.4.0"
-sourmash = { git = "https://github.com/sourmash-bio/sourmash", branch = "lirber/mastiff", features = ["branchwater"] }
-#sourmash = { path = "../sm_worktrees/mastiff/src/core", features = ["branchwater"] }
+sourmash = { version = "0.12.0", features = ["branchwater"] }
 
 serde_json = "1.0.83"
 # axum deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ niffler = { version = "2.4.0", default-features = false, features = [ "gz" ]}
 numsep = "0.1.12"
 reqwest = { version = "0.11.11", default-features = false, features = [ "blocking", "rustls-tls" ] }
 size = "0.4.0"
-#sourmash = { git = "https://github.com/sourmash-bio/sourmash", branch = "lirber/mastiff", features = ["branchwater"] }
-sourmash = { path = "../sm_worktrees/mastiff/src/core", features = ["branchwater"] }
+sourmash = { git = "https://github.com/sourmash-bio/sourmash", branch = "lirber/mastiff", features = ["branchwater"] }
+#sourmash = { path = "../sm_worktrees/mastiff/src/core", features = ["branchwater"] }
 
 serde_json = "1.0.83"
 # axum deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,14 @@
 [workspace]
 members = ["crates/*"]
 default-members = ["crates/server"]
+resolver = "2"
 
 [workspace.package]
 version = "0.1.0"
 name = "mastiff"
 
 [workspace.dependencies]
+camino = "1.1.6"
 clap = { version = "3.2.8", features = [ "derive" ] }
 color-eyre = "0.6.2"
 csv = "1.1.6"
@@ -18,7 +20,8 @@ niffler = { version = "2.4.0", default-features = false, features = [ "gz" ]}
 numsep = "0.1.12"
 reqwest = { version = "0.11.11", default-features = false, features = [ "blocking", "rustls-tls" ] }
 size = "0.4.0"
-sourmash = { git = "https://github.com/sourmash-bio/sourmash", tag = "mastiff_roaring" }
+#sourmash = { git = "https://github.com/sourmash-bio/sourmash", branch = "lirber/mastiff", features = ["branchwater"] }
+sourmash = { path = "../sm_worktrees/mastiff/src/core", features = ["branchwater"] }
 
 serde_json = "1.0.83"
 # axum deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/server", "crates/client"]
+members = ["crates/*"]
 default-members = ["crates/server"]
 
 [workspace.package]
@@ -11,10 +11,13 @@ clap = { version = "3.2.8", features = [ "derive" ] }
 color-eyre = "0.6.2"
 csv = "1.1.6"
 env_logger = "0.9.0"
+histogram = "0.6.9"
 log = "0.4.17"
 needletail = "0.4.1"
 niffler = { version = "2.4.0", default-features = false, features = [ "gz" ]}
+numsep = "0.1.12"
 reqwest = { version = "0.11.11", default-features = false, features = [ "blocking", "rustls-tls" ] }
+size = "0.4.0"
 sourmash = { git = "https://github.com/sourmash-bio/sourmash", tag = "mastiff_roaring" }
 
 serde_json = "1.0.83"

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -107,7 +107,7 @@ fn main() -> Result<()> {
         let mut sigs = Signature::load_signatures(
             &mut reader,
             Some(21),
-            Some(HashFunctions::murmur64_DNA),
+            Some(HashFunctions::Murmur64Dna),
             Some(1000),
         )?;
 

--- a/crates/index/Cargo.toml
+++ b/crates/index/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "mastiff-index"
+version.workspace = true
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+clap.workspace = true
+env_logger.workspace = true
+histogram.workspace = true
+log.workspace = true
+numsep.workspace = true
+size.workspace = true
+sourmash.workspace = true

--- a/crates/index/Cargo.toml
+++ b/crates/index/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mastiff-index"
 version.workspace = true
 edition = "2021"
+license = "AGPL"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/index/Cargo.toml
+++ b/crates/index/Cargo.toml
@@ -7,6 +7,7 @@ license = "AGPL"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+camino.workspace = true
 clap.workspace = true
 env_logger.workspace = true
 histogram.workspace = true

--- a/crates/index/src/main.rs
+++ b/crates/index/src/main.rs
@@ -1,0 +1,429 @@
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+use clap::{Parser, Subcommand};
+use log::info;
+
+use sourmash::index::revindex::{prepare_query, RevIndex};
+use sourmash::signature::{Signature, SigsTrait};
+use sourmash::sketch::minhash::{max_hash_for_scaled, KmerMinHash};
+use sourmash::sketch::Sketch;
+
+fn build_template(ksize: u8, scaled: usize) -> Sketch {
+    let max_hash = max_hash_for_scaled(scaled as u64);
+    let template_mh = KmerMinHash::builder()
+        .num(0u32)
+        .ksize(ksize as u32)
+        .max_hash(max_hash)
+        .build();
+    Sketch::MinHash(template_mh)
+}
+
+fn read_paths<P: AsRef<Path>>(paths_file: P) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
+    let paths = BufReader::new(File::open(paths_file)?);
+    Ok(paths
+        .lines()
+        .map(|line| {
+            let mut path = PathBuf::new();
+            path.push(line.unwrap());
+            path
+        })
+        .collect())
+}
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+    Index {
+        /// List of signatures to search
+        #[clap(parse(from_os_str))]
+        siglist: PathBuf,
+
+        /// ksize
+        #[clap(short, long, default_value = "31")]
+        ksize: u8,
+
+        /// threshold
+        #[clap(short, long, default_value = "0")]
+        threshold: f64,
+
+        /// scaled
+        #[clap(short, long, default_value = "1000")]
+        scaled: usize,
+
+        /// save paths to signatures into index. Default: save full sig into index
+        #[clap(long)]
+        save_paths: bool,
+
+        /// The path for output
+        #[clap(parse(from_os_str), short, long)]
+        output: PathBuf,
+
+        /// Index using colors
+        #[clap(long = "colors")]
+        colors: bool,
+    },
+    Update {
+        /// List of signatures to search
+        #[clap(parse(from_os_str))]
+        siglist: PathBuf,
+
+        /// ksize
+        #[clap(short, long, default_value = "31")]
+        ksize: u8,
+
+        /// threshold
+        #[clap(short, long, default_value = "0")]
+        threshold: f64,
+
+        /// scaled
+        #[clap(short, long, default_value = "1000")]
+        scaled: usize,
+
+        /// save paths to signatures into index. Default: save full sig into index
+        #[clap(long)]
+        save_paths: bool,
+
+        /// The path for output
+        #[clap(parse(from_os_str), short, long)]
+        output: PathBuf,
+
+        /// Index using colors
+        #[clap(long = "colors")]
+        colors: bool,
+    },
+    /* TODO: need the repair_cf variant, not available in rocksdb-rust yet
+        Repair {
+            /// The path for DB to repair
+            #[clap(parse(from_os_str))]
+            index: PathBuf,
+
+            /// Repair using colors
+            #[clap(long = "colors")]
+            colors: bool,
+        },
+    */
+    Check {
+        /// The path for output
+        #[clap(parse(from_os_str))]
+        output: PathBuf,
+
+        /// avoid deserializing data, and without stats
+        #[clap(long = "quick")]
+        quick: bool,
+    },
+    Convert {
+        /// The path for the input DB
+        #[clap(parse(from_os_str))]
+        input: PathBuf,
+
+        /// The path for the output DB
+        #[clap(parse(from_os_str))]
+        output: PathBuf,
+    },
+    Search {
+        /// Query signature
+        #[clap(parse(from_os_str))]
+        query_path: PathBuf,
+
+        /// Path to rocksdb index dir
+        #[clap(parse(from_os_str))]
+        index: PathBuf,
+
+        /// ksize
+        #[clap(short = 'k', long = "ksize", default_value = "31")]
+        ksize: u8,
+
+        /// scaled
+        #[clap(short = 's', long = "scaled", default_value = "1000")]
+        scaled: usize,
+
+        /// threshold_bp
+        #[clap(short = 't', long = "threshold_bp", default_value = "50000")]
+        threshold_bp: usize,
+
+        /// minimum containment to report
+        #[clap(short = 'c', long = "containment", default_value = "0.2")]
+        containment: f64,
+
+        /// The path for output
+        #[clap(parse(from_os_str), short = 'o', long = "output")]
+        output: Option<PathBuf>,
+    },
+    Gather {
+        /// Query signature
+        #[clap(parse(from_os_str))]
+        query_path: PathBuf,
+
+        /// Path to rocksdb index dir
+        #[clap(parse(from_os_str))]
+        index: PathBuf,
+
+        /// ksize
+        #[clap(short = 'k', long = "ksize", default_value = "31")]
+        ksize: u8,
+
+        /// scaled
+        #[clap(short = 's', long = "scaled", default_value = "1000")]
+        scaled: usize,
+
+        /// threshold_bp
+        #[clap(short = 't', long = "threshold_bp", default_value = "50000")]
+        threshold_bp: usize,
+
+        /// The path for output
+        #[clap(parse(from_os_str), short = 'o', long = "output")]
+        output: Option<PathBuf>,
+    },
+}
+
+fn gather<P: AsRef<Path>>(
+    queries_file: P,
+    index: P,
+    template: Sketch,
+    threshold_bp: usize,
+    _output: Option<P>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let query_sig = Signature::from_path(queries_file)?;
+
+    let mut query = None;
+    for sig in &query_sig {
+        if let Some(q) = prepare_query(sig, &template) {
+            query = Some(q);
+        }
+    }
+    let query = query.expect("Couldn't find a compatible MinHash");
+
+    let threshold = threshold_bp / query.scaled() as usize;
+
+    let db = RevIndex::open(index.as_ref(), true);
+    info!("Loaded DB");
+
+    info!("Building counter");
+    let (counter, query_colors, hash_to_color) = db.prepare_gather_counters(&query);
+    // TODO: truncate on threshold?
+    info!("Counter built");
+
+    let matches = db.gather(
+        counter,
+        query_colors,
+        hash_to_color,
+        threshold,
+        &query,
+        &template,
+    )?;
+
+    info!("matches: {}", matches.len());
+    for match_ in matches {
+        println!(
+            "{} {} {}",
+            match_.name(),
+            match_.intersect_bp(),
+            match_.f_match()
+        )
+    }
+
+    Ok(())
+}
+
+fn search<P: AsRef<Path>>(
+    queries_file: P,
+    index: P,
+    template: Sketch,
+    threshold_bp: usize,
+    minimum_containment: f64,
+    _output: Option<P>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let query_sig = Signature::from_path(queries_file)?;
+
+    let mut query = None;
+    for sig in &query_sig {
+        if let Some(q) = prepare_query(sig, &template) {
+            query = Some(q);
+        }
+    }
+    let query = query.expect("Couldn't find a compatible MinHash");
+    let query_size = query.size() as f64;
+
+    let threshold = threshold_bp / query.scaled() as usize;
+
+    let db = RevIndex::open(index.as_ref(), true);
+    info!("Loaded DB");
+
+    info!("Building counter");
+    let counter = db.counter_for_query(&query);
+    info!("Counter built");
+
+    let matches = db.matches_from_counter(counter, threshold);
+
+    //info!("matches: {}", matches.len());
+    println!("SRA ID,containment");
+    matches
+        .into_iter()
+        .filter_map(|(path, size)| {
+            let containment = size as f64 / query_size;
+            if containment >= minimum_containment {
+                println!(
+                    "{},{}",
+                    path.split("/").last().unwrap().split(".").next().unwrap(),
+                    containment
+                );
+                Some(())
+            } else {
+                None
+            }
+        })
+        .count();
+
+    Ok(())
+}
+
+fn index<P: AsRef<Path>>(
+    siglist: P,
+    template: Sketch,
+    threshold: f64,
+    output: P,
+    save_paths: bool,
+    colors: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    info!("Loading siglist");
+    let index_sigs = read_paths(siglist)?;
+    info!("Loaded {} sig paths in siglist", index_sigs.len());
+
+    let db = RevIndex::create(output.as_ref(), colors);
+    db.index(index_sigs, &template, threshold, save_paths);
+
+    Ok(())
+}
+
+fn update<P: AsRef<Path>>(
+    siglist: P,
+    template: Sketch,
+    threshold: f64,
+    output: P,
+    save_paths: bool,
+    _colors: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    info!("Loading siglist");
+    let index_sigs = read_paths(siglist)?;
+    info!("Loaded {} sig paths in siglist", index_sigs.len());
+
+    let db = RevIndex::open(output.as_ref(), false);
+    db.update(index_sigs, &template, threshold, save_paths);
+
+    Ok(())
+}
+
+fn convert<P: AsRef<Path>>(input: P, output: P) -> Result<(), Box<dyn std::error::Error>> {
+    info!("Opening input DB");
+    let db = RevIndex::open(input.as_ref(), true);
+
+    info!("Creating output DB");
+    let output_db = RevIndex::create(output.as_ref(), true);
+
+    info!("Converting input DB");
+    db.convert(output_db)?;
+
+    info!("Finished conversion");
+    Ok(())
+}
+
+fn check<P: AsRef<Path>>(output: P, quick: bool) -> Result<(), Box<dyn std::error::Error>> {
+    info!("Opening DB");
+    let db = RevIndex::open(output.as_ref(), true);
+
+    info!("Starting check");
+    db.check(quick);
+
+    info!("Finished check");
+    Ok(())
+}
+
+/* TODO: need the repair_cf variant, not available in rocksdb-rust yet
+fn repair<P: AsRef<Path>>(output: P, colors: bool) {
+    info!("Starting repair");
+    RevIndex::repair(output.as_ref(), colors);
+    info!("Finished repair");
+}
+*/
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    use Commands::*;
+
+    let opts = Cli::parse();
+
+    match opts.command {
+        Index {
+            output,
+            siglist,
+            threshold,
+            ksize,
+            scaled,
+            save_paths,
+            colors,
+        } => {
+            let template = build_template(ksize, scaled);
+
+            index(siglist, template, threshold, output, save_paths, colors)?
+        }
+        Update {
+            output,
+            siglist,
+            threshold,
+            ksize,
+            scaled,
+            save_paths,
+            colors,
+        } => {
+            let template = build_template(ksize, scaled);
+
+            update(siglist, template, threshold, output, save_paths, colors)?
+        }
+        Check { output, quick } => check(output, quick)?,
+        Convert { input, output } => convert(input, output)?,
+        Search {
+            query_path,
+            output,
+            index,
+            threshold_bp,
+            ksize,
+            scaled,
+            containment,
+        } => {
+            let template = build_template(ksize, scaled);
+
+            search(
+                query_path,
+                index,
+                template,
+                threshold_bp,
+                containment,
+                output,
+            )?
+        }
+        Gather {
+            query_path,
+            output,
+            index,
+            threshold_bp,
+            ksize,
+            scaled,
+        } => {
+            let template = build_template(ksize, scaled);
+
+            gather(query_path, index, template, threshold_bp, output)?
+        } /* TODO: need the repair_cf variant, not available in rocksdb-rust yet
+                  Repair { index, colors } => repair(index, colors),
+          */
+    };
+
+    Ok(())
+}

--- a/crates/index/src/main.rs
+++ b/crates/index/src/main.rs
@@ -285,8 +285,10 @@ fn index<P: AsRef<Path>>(
         }
     } else {
         let manifest = manifest.ok_or_else(|| "Need a manifest")?;
+        assert!(location.as_ref().exists());
+        assert!(location.as_ref().is_dir());
         let storage = FSStorage::builder()
-            .fullpath("".into())
+            .fullpath(location.as_ref().into())
             .subdir("".into())
             .build();
         Collection::new(manifest, InnerStorage::new(storage))
@@ -323,8 +325,10 @@ fn update<P: AsRef<Path>>(
         }
     } else {
         let manifest = manifest.ok_or_else(|| "Need a manifest")?;
+        assert!(location.as_ref().exists());
+        assert!(location.as_ref().is_dir());
         let storage = FSStorage::builder()
-            .fullpath("".into())
+            .fullpath(location.as_ref().into())
             .subdir("".into())
             .build();
         Collection::new(manifest, InnerStorage::new(storage))

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -6,7 +6,7 @@ use axum::{
     extract::{ContentLengthLimit, Extension},
     http::{header, StatusCode},
     response::{IntoResponse, Response},
-    routing::{get_service, post},
+    routing::{get, get_service, post},
     Router,
 };
 use sentry::integrations::tower::{NewSentryLayer, SentryHttpLayer};
@@ -101,6 +101,7 @@ fn main() -> Result<()> {
     // Build our application by composing routes
     let app = Router::new()
         .route("/search", post(search))
+        .route("/health", get(health))
         //.route("/gather", post(gather))
         .fallback(get_service(ServeDir::new(opts.assets)).handle_error(handle_static_serve_error))
         // Add middleware to all routes
@@ -221,6 +222,10 @@ async fn search(
         )
             .into_response(),
     }
+}
+
+async fn health() -> Response<BoxBody> {
+    (StatusCode::OK, "I'm doing science and I'm still alive").into_response()
 }
 
 async fn handle_static_serve_error(error: std::io::Error) -> impl IntoResponse {

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -18,7 +18,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use clap::Parser;
 use color_eyre::eyre::Result;
-use sourmash::index::revindex::RevIndex;
+use sourmash::index::revindex::{RevIndex, RevIndexOps};
 use sourmash::signature::{Signature, SigsTrait};
 use sourmash::sketch::minhash::{max_hash_for_scaled, KmerMinHash};
 use sourmash::sketch::Sketch;
@@ -159,8 +159,9 @@ impl State {
                 Err("Could not extract compatible sketch to compare")
             }
         })
-        .await? else {
-            return Err("Could not extract compatible sketch to compare".into())
+        .await?
+        else {
+            return Err("Could not extract compatible sketch to compare".into());
         };
 
         let mut csv = vec!["SRA accession,containment".into()];

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -93,7 +93,7 @@ fn main() -> Result<()> {
     let threshold = opts.threshold_bp / mh.scaled() as usize;
 
     let state = Arc::new(State {
-        db: Arc::new(RevIndex::open(opts.index.as_ref(), true)),
+        db: Arc::new(RevIndex::open(opts.index, true).expect("Error opening DB")),
         template: Arc::new(Sketch::MinHash(mh)),
         threshold,
     });

--- a/experiments/Snakefile
+++ b/experiments/Snakefile
@@ -59,63 +59,58 @@ rule extract_rs_207_manifest:
 
 #######################################################################
 
-#rule metag_all:
-#    output: directory("/scratch/analysis/metag_k21_s{scaled,\d+}-roaring")
-#    params:
-#        scaled = "{scaled}"
-#    shell: """
-#        {EXEC} index -k 21 -s {params.scaled} \
-#            --output {output} \
-#            --save-paths \
-#            catalog_metagenomes
-#    """
-
-rule metag_all_update:
+rule metag_100:
+    output: directory("outputs/metag-100")
     input:
-        updated="updated_catalog"
-    params:
-        scaled = "1000"
+      storage="/data/wort/wort-sra",
+      manifest="inputs/metagenomes-k21-s1000-test.manifest"
+    threads: 24
     shell: """
-        {EXEC} update -k 21 -s {params.scaled} \
-            --output /scratch/analysis/metag_k21_s{params.scaled}-roaring \
-            --save-paths \
-            {input.updated}
+        export RAYON_NUM_THREADS={threads}
+        RUST_LOG=info {EXEC} index -k 21 -s 1000 \
+          --output {output} \
+          --manifest <(head -102 {input.manifest}) \
+          {input.storage}
     """
 
-rule metag_fullcolors:
-    output: directory("outputs/fullcolors")
+rule metag_200:
+    output: directory("outputs/metag-200")
+    input:
+      previous="outputs/metag-100",
+      storage="/data/wort/wort-sra",
+      manifest="inputs/metagenomes-k21-s1000-test.manifest"
+    threads: 24
     shell: """
-        {EXEC} index -k 21 -s 1000 \
-            --output {output} \
-            --colors \
-            <(head -1 catalog_metagenomes | xargs yes | head -1000)
+        export RAYON_NUM_THREADS={threads}
+        cp -a {input.previous} {output}
+        {EXEC} update -k 21 -s 1000 \
+          --output {output} \
+          --manifest <(head -202 {input.manifest}) \
+          {input.storage}
     """
 
-rule metag_1k:
-    output: directory("outputs/metag-1k")
+rule manifest_test:
+    output:
+        manifest="inputs/metagenomes-k{ksize}-s1000-test.manifest",
+    input:
+        catalog="outputs/metagenomes-catalog",
+    threads: 24,
     shell: """
-        {EXEC} index -k 21 -s 1000 \
+        export RAYON_NUM_THREADS={threads}
+        RUST_LOG=info {EXEC} manifest -k 21 \
             --output {output} \
-            --save-paths \
-            <(head -1000 catalog_metagenomes)
+            --basepath /data/wort/wort-sra \
+            <(head -2000 {input.catalog})
     """
 
-rule metag_1k_colors:
-    output: directory("outputs/metag-1k-colors")
-    shell: """
-        RUST_LOG=trace {EXEC} index -k 21 -s 1000 \
-            --output {output} \
-            --colors \
-            --save-paths \
-            <(head -1000 catalog_metagenomes)
-    """
+#######################################################################
 
 rule manifest_from_catalog:
     output:
         manifest="outputs/metagenomes-k{ksize}-s1000.manifest",
     input:
         catalog="outputs/metagenomes-catalog",
-    thread: 24,
+    threads: 24,
     shell: """
         export RAYON_NUM_THREADS={threads}
         RUST_LOG=info {EXEC} manifest -k 21 \

--- a/experiments/Snakefile
+++ b/experiments/Snakefile
@@ -2,7 +2,8 @@ EXEC="cargo run -p mastiff-index --release -- "
 
 rule all:
 #    input: "outputs/rs207"
-    input: "outputs/rs207-2k"
+#    input: "outputs/rs207-2k"
+    input: expand("outputs/genbank-{domain}", domain=["archaea", "bacteria", "fungi", "protozoa", "viral"])
 
 rule rs207_1k:
     output: directory("outputs/rs207-1k")
@@ -148,6 +149,21 @@ rule catalog_metagenomes:
                 sig_path = path / "sigs" / f"{sra_id}.sig"
                 if sig_path.exists():
                     out.write(f"{sig_path}\n")
+                    out.flush()
+
+#######################################################################
+
+rule genbank:
+    output: directory("outputs/genbank-{domain}")
+    input: "/data/wort/databases/genbank-2022.03-{domain}-k21.zip"
+
+    shell: """
+        {EXEC} index -k 21 -s 1000 \
+            --output {output} \
+            {input}
+    """
+
+#######################################################################
 
 """
 {EXEC} index -k 21 -s 1000 --output /scratch/analysis/rocksdb_metagenomes catalog_metagenomes

--- a/experiments/Snakefile
+++ b/experiments/Snakefile
@@ -109,12 +109,26 @@ rule metag_1k_colors:
             <(head -1000 catalog_metagenomes)
     """
 
-rule new_catalog:
+rule manifest_from_catalog:
     output:
-        new_catalog="updated_catalog",
+        manifest="outputs/metagenomes-k{ksize}-s1000.manifest",
     input:
-        original="catalog_metagenomes",
-        runinfo="runinfo.csv"
+        catalog="outputs/metagenomes-catalog",
+    thread: 24,
+    shell: """
+        export RAYON_NUM_THREADS={threads}
+        RUST_LOG=info {EXEC} manifest -k 21 \
+            --output {output} \
+            --basepath /data/wort/wort-sra \
+            {input.catalog}
+    """
+
+rule catalog_metagenomes:
+    output:
+        catalog="outputs/metagenomes-catalog",
+    input:
+        runinfo="runinfo-20230817.csv",
+        basepath="/data/wort/wort-sra/"
     run:
         import csv
         from pathlib import Path
@@ -127,22 +141,11 @@ rule new_catalog:
                 if dataset['Run'] != 'Run':
                     sraids.add(dataset['Run'])
 
-        with open(output.new_catalog, 'w') as out:
-            # remove current datasets already in the catalog
-            with open(input.original) as fp:
-                for line in fp:
-                    # write current line (to keep order)
-                    out.write(line)
-
-                    parts = line.strip().split('/')
-                    sra_id = parts[-1].split('.')[0]
-                    if sra_id in sraids:
-                        sraids.remove(sra_id)
-
-            path = Path("/".join(parts[:-1]))
-            # check if remaining sraids exist on disk
+        path = Path(input.basepath)
+        with open(output.catalog, 'w') as out:
+            # check if sraids exist on disk
             for sra_id in sraids:
-                sig_path = path / f"{sra_id}.sig"
+                sig_path = path / "sigs" / f"{sra_id}.sig"
                 if sig_path.exists():
                     out.write(f"{sig_path}\n")
 

--- a/experiments/Snakefile
+++ b/experiments/Snakefile
@@ -14,25 +14,16 @@ rule bacteria_1k:
           <(head -1000 {input})
     """
 
-rule bacteria_1k_save_paths:
-    output: directory("outputs/bacteria-1k-save-paths")
-    shell: """
-        {EXEC} index -k 51 -s 1000 \
-          --output {output} \
-          --save-paths \
-          <(head -1000 flist)
-    """
-
 rule bacteria_2k:
     output: directory("outputs/bacteria-2k")
     input: 
-        previous=directory("outputs/bacteria-1k-save-paths"),
+        previous="outputs/bacteria-1k",
+        manifest="inputs/gtdb-rs207.genomic-reps.dna.k21.manifest",
     shell: """
         cp -a {input.previous} {output}
-        {EXEC} update -k 51 -s 1000 \
+        {EXEC} update -k 21 -s 1000 \
           --output {output} \
-          --save-paths \
-          <(head -2000 flist)
+          <(head -2000 {input.manifest})
     """
 
 rule bacteria_1k_colors:

--- a/experiments/Snakefile
+++ b/experiments/Snakefile
@@ -1,0 +1,202 @@
+rule bacteria_1k:
+    output: directory("outputs/bacteria-1k")
+    shell: """
+        cargo run --release -- index -k 51 -s 1000 \
+          --output {output} \
+          <(head -1000 flist)
+    """
+
+rule bacteria_1k_save_paths:
+    output: directory("outputs/bacteria-1k-save-paths")
+    shell: """
+        cargo run --release -- index -k 51 -s 1000 \
+          --output {output} \
+          --save-paths \
+          <(head -1000 flist)
+    """
+
+rule bacteria_2k:
+    output: directory("outputs/bacteria-2k")
+    input: 
+        previous=directory("outputs/bacteria-1k-save-paths"),
+    shell: """
+        cp -a {input.previous} {output}
+        cargo run --release -- update -k 51 -s 1000 \
+          --output {output} \
+          --save-paths \
+          <(head -2000 flist)
+    """
+
+rule bacteria_1k_colors:
+    output: directory("outputs/bacteria-1k-colors")
+    shell: """
+        RUST_LOG=debug cargo run --release -- index -k 51 -s 1000 --colors \
+          --output {output} \
+          <(head -1000 flist)
+    """
+
+rule bacteria_10k:
+    output: directory("outputs/bacteria-10k")
+    shell: """
+        cargo run --release -- index -k 51 -s 1000 \
+          --output {output} \
+          <(head -10000 flist)
+    """
+
+rule bacteria_10k_colors:
+    output: directory("outputs/bacteria-10k-colors")
+    shell: """
+        cargo run --release -- index -k 51 -s 1000 --colors \
+          --output {output} \
+          <(head -10000 flist)
+    """
+
+rule bacteria_fullcolors:
+    output: directory("outputs/bacteria-fullcolors")
+    shell: """
+        cargo run --release -- index -k 51 -s 1000 --colors \
+          --output {output} \
+          <(head -1 flist | xargs yes | head -1000)
+    """
+
+rule bacteria_k51_s1000:
+    output: directory("outputs/bacteria-k51-s1000")
+    benchmark:
+        "benchmarks/bacteria-k51-s1000.tsv"
+    shell: """
+        cargo run --release -- index -k 51 -s 1000 \
+          --output {output} \
+          flist_bacteria-k51
+    """
+
+
+#rule metag_all:
+#    output: directory("/scratch/analysis/metag_k21_s{scaled,\d+}-roaring")
+#    params:
+#        scaled = "{scaled}"
+#    shell: """
+#        cargo run --release -- index -k 21 -s {params.scaled} \
+#            --output {output} \
+#            --save-paths \
+#            catalog_metagenomes
+#    """
+
+rule metag_all_update:
+    input:
+        updated="updated_catalog"
+    params:
+        scaled = "1000"
+    shell: """
+        cargo run --release -- update -k 21 -s {params.scaled} \
+            --output /scratch/analysis/metag_k21_s{params.scaled}-roaring \
+            --save-paths \
+            {input.updated}
+    """
+
+rule metag_fullcolors:
+    output: directory("outputs/fullcolors")
+    shell: """
+        cargo run --release -- index -k 21 -s 1000 \
+            --output {output} \
+            --colors \
+            <(head -1 catalog_metagenomes | xargs yes | head -1000)
+    """
+
+rule metag_1k:
+    output: directory("outputs/metag-1k")
+    shell: """
+        cargo run --release -- index -k 21 -s 1000 \
+            --output {output} \
+            --save-paths \
+            <(head -1000 catalog_metagenomes)
+    """
+
+rule metag_1k_colors:
+    output: directory("outputs/metag-1k-colors")
+    shell: """
+        RUST_LOG=trace cargo run --release -- index -k 21 -s 1000 \
+            --output {output} \
+            --colors \
+            --save-paths \
+            <(head -1000 catalog_metagenomes)
+    """
+
+rule download_rs_207:
+    output: "inputs/gtdb-rs207.genomic-reps.dna.k21.zip"
+    shell: """
+        curl -L https://osf.io/download/f2wzc/ -o {output}
+    """
+
+rule extract_rs_207:
+    output: 
+        manifest="inputs/gtdb-rs207.genomic-reps.dna.k21.manifest",
+        data=directory("inputs/gtdb-rs207.genomic-reps.dna.k21")
+    input: "inputs/gtdb-rs207.genomic-reps.dna.k21.zip"
+    shell: """
+        python -m zipfile -e {input} {output.data}
+        find `realpath {output.data}` -iname "*.sig.gz" > {output.manifest}
+    """
+
+rule rs_207:
+    output: directory("outputs/rs207")
+    input: 
+      manifest="inputs/gtdb-rs207.genomic-reps.dna.k21.manifest",
+      data=directory("inputs/gtdb-rs207.genomic-reps.dna.k21")
+    shell: """
+        RUST_LOG=trace cargo run --release -- index -k 21 -s 1000 \
+            --output {output} \
+            {input.manifest}
+    """
+
+rule new_catalog:
+    output:
+        new_catalog="updated_catalog",
+    input:
+        original="catalog_metagenomes",
+        runinfo="runinfo.csv"
+    run:
+        import csv
+        from pathlib import Path
+
+        # load all sra IDs
+        sraids = set()
+        with open(input.runinfo) as fp:
+            data = csv.DictReader(fp, delimiter=",")
+            for dataset in data:
+                if dataset['Run'] != 'Run':
+                    sraids.add(dataset['Run'])
+
+        with open(output.new_catalog, 'w') as out:
+            # remove current datasets already in the catalog
+            with open(input.original) as fp:
+                for line in fp:
+                    # write current line (to keep order)
+                    out.write(line)
+
+                    parts = line.strip().split('/')
+                    sra_id = parts[-1].split('.')[0]
+                    if sra_id in sraids:
+                        sraids.remove(sra_id)
+
+            path = Path("/".join(parts[:-1]))
+            # check if remaining sraids exist on disk
+            for sra_id in sraids:
+                sig_path = path / f"{sra_id}.sig"
+                if sig_path.exists():
+                    out.write(f"{sig_path}\n")
+
+"""
+cargo run --release -- index -k 21 -s 1000 --output /scratch/analysis/rocksdb_metagenomes catalog_metagenomes                                                                               │ 
+cargo run --release -- index -k 21 -s 10000 --output /scratch/analysis/rocksdb_metagenomes2 <(cat catalog_metagenomes | head 1000)                                                          │ 
+cargo run --release -- index -k 21 -s 1000 --output /scratch/analysis/rocksdb_metagenomes2 <(cat catalog_metagenomes | head -n 10)                                                          │
+cargo run --release -- index -k 21 -s 10000 --output /scratch/analysis/rocksdb_metagenomes2 <(cat catalog_metagenomes | head -n 10)                                                         │ 
+cargo run --release -- index -k 21 -s 10000 --output /scratch/analysis/rocksdb_metagenomes2 <(cat catalog_metagenomes | head -n 1000)                                                       │
+cargo run --release -- index -k 51 -s 1000 --output bacteria-100k-enum flist                                                                                                                │
+cargo run --release -- index -k 51 -s 1000 --output bacteria-100k-cf <(head -1 flist)                                                                                                       │
+cargo run --release -- index -k 51 -s 1000 --output bacteria-1k-cf (head -1000 flist)                                                                                                       │
+cargo run --release -- index -k 51 -s 1000 --output bacteria-1k-cf $(head -1000 flist)                                                                                                      │
+cargo run --release -- index -k 51 -s 1000 --output bacteria-10k-cf <(head -10000 flist)                                                                                                    │
+cargo run --release -- index -k 51 -s 1000 --output bacteria-100k-cf flist                                                                                                                  │
+cargo run --release -- index -k 51 -s 1000 --output bacteria-1k-cf-opts <(head -1000 flist)                                                                                                 │
+cargo run --release -- index -k 51 -s 1000 --output bacteria-100k-cf-opts flist 
+"""

--- a/experiments/Snakefile
+++ b/experiments/Snakefile
@@ -1,7 +1,9 @@
+EXEC="cargo run -p mastiff-index --release -- "
+
 rule bacteria_1k:
     output: directory("outputs/bacteria-1k")
     shell: """
-        cargo run --release -- index -k 51 -s 1000 \
+        {EXEC} index -k 51 -s 1000 \
           --output {output} \
           <(head -1000 flist)
     """
@@ -9,7 +11,7 @@ rule bacteria_1k:
 rule bacteria_1k_save_paths:
     output: directory("outputs/bacteria-1k-save-paths")
     shell: """
-        cargo run --release -- index -k 51 -s 1000 \
+        {EXEC} index -k 51 -s 1000 \
           --output {output} \
           --save-paths \
           <(head -1000 flist)
@@ -21,7 +23,7 @@ rule bacteria_2k:
         previous=directory("outputs/bacteria-1k-save-paths"),
     shell: """
         cp -a {input.previous} {output}
-        cargo run --release -- update -k 51 -s 1000 \
+        {EXEC} update -k 51 -s 1000 \
           --output {output} \
           --save-paths \
           <(head -2000 flist)
@@ -30,7 +32,7 @@ rule bacteria_2k:
 rule bacteria_1k_colors:
     output: directory("outputs/bacteria-1k-colors")
     shell: """
-        RUST_LOG=debug cargo run --release -- index -k 51 -s 1000 --colors \
+        RUST_LOG=debug {EXEC} index -k 51 -s 1000 --colors \
           --output {output} \
           <(head -1000 flist)
     """
@@ -38,7 +40,7 @@ rule bacteria_1k_colors:
 rule bacteria_10k:
     output: directory("outputs/bacteria-10k")
     shell: """
-        cargo run --release -- index -k 51 -s 1000 \
+        {EXEC} index -k 51 -s 1000 \
           --output {output} \
           <(head -10000 flist)
     """
@@ -46,7 +48,7 @@ rule bacteria_10k:
 rule bacteria_10k_colors:
     output: directory("outputs/bacteria-10k-colors")
     shell: """
-        cargo run --release -- index -k 51 -s 1000 --colors \
+        {EXEC} index -k 51 -s 1000 --colors \
           --output {output} \
           <(head -10000 flist)
     """
@@ -54,7 +56,7 @@ rule bacteria_10k_colors:
 rule bacteria_fullcolors:
     output: directory("outputs/bacteria-fullcolors")
     shell: """
-        cargo run --release -- index -k 51 -s 1000 --colors \
+        {EXEC} index -k 51 -s 1000 --colors \
           --output {output} \
           <(head -1 flist | xargs yes | head -1000)
     """
@@ -64,7 +66,7 @@ rule bacteria_k51_s1000:
     benchmark:
         "benchmarks/bacteria-k51-s1000.tsv"
     shell: """
-        cargo run --release -- index -k 51 -s 1000 \
+        {EXEC} index -k 51 -s 1000 \
           --output {output} \
           flist_bacteria-k51
     """
@@ -75,7 +77,7 @@ rule bacteria_k51_s1000:
 #    params:
 #        scaled = "{scaled}"
 #    shell: """
-#        cargo run --release -- index -k 21 -s {params.scaled} \
+#        {EXEC} index -k 21 -s {params.scaled} \
 #            --output {output} \
 #            --save-paths \
 #            catalog_metagenomes
@@ -87,7 +89,7 @@ rule metag_all_update:
     params:
         scaled = "1000"
     shell: """
-        cargo run --release -- update -k 21 -s {params.scaled} \
+        {EXEC} update -k 21 -s {params.scaled} \
             --output /scratch/analysis/metag_k21_s{params.scaled}-roaring \
             --save-paths \
             {input.updated}
@@ -96,7 +98,7 @@ rule metag_all_update:
 rule metag_fullcolors:
     output: directory("outputs/fullcolors")
     shell: """
-        cargo run --release -- index -k 21 -s 1000 \
+        {EXEC} index -k 21 -s 1000 \
             --output {output} \
             --colors \
             <(head -1 catalog_metagenomes | xargs yes | head -1000)
@@ -105,7 +107,7 @@ rule metag_fullcolors:
 rule metag_1k:
     output: directory("outputs/metag-1k")
     shell: """
-        cargo run --release -- index -k 21 -s 1000 \
+        {EXEC} index -k 21 -s 1000 \
             --output {output} \
             --save-paths \
             <(head -1000 catalog_metagenomes)
@@ -114,7 +116,7 @@ rule metag_1k:
 rule metag_1k_colors:
     output: directory("outputs/metag-1k-colors")
     shell: """
-        RUST_LOG=trace cargo run --release -- index -k 21 -s 1000 \
+        RUST_LOG=trace {EXEC} index -k 21 -s 1000 \
             --output {output} \
             --colors \
             --save-paths \
@@ -143,7 +145,7 @@ rule rs_207:
       manifest="inputs/gtdb-rs207.genomic-reps.dna.k21.manifest",
       data=directory("inputs/gtdb-rs207.genomic-reps.dna.k21")
     shell: """
-        RUST_LOG=trace cargo run --release -- index -k 21 -s 1000 \
+        RUST_LOG=trace {EXEC} index -k 21 -s 1000 \
             --output {output} \
             {input.manifest}
     """
@@ -186,17 +188,17 @@ rule new_catalog:
                     out.write(f"{sig_path}\n")
 
 """
-cargo run --release -- index -k 21 -s 1000 --output /scratch/analysis/rocksdb_metagenomes catalog_metagenomes                                                                               │ 
-cargo run --release -- index -k 21 -s 10000 --output /scratch/analysis/rocksdb_metagenomes2 <(cat catalog_metagenomes | head 1000)                                                          │ 
-cargo run --release -- index -k 21 -s 1000 --output /scratch/analysis/rocksdb_metagenomes2 <(cat catalog_metagenomes | head -n 10)                                                          │
-cargo run --release -- index -k 21 -s 10000 --output /scratch/analysis/rocksdb_metagenomes2 <(cat catalog_metagenomes | head -n 10)                                                         │ 
-cargo run --release -- index -k 21 -s 10000 --output /scratch/analysis/rocksdb_metagenomes2 <(cat catalog_metagenomes | head -n 1000)                                                       │
-cargo run --release -- index -k 51 -s 1000 --output bacteria-100k-enum flist                                                                                                                │
-cargo run --release -- index -k 51 -s 1000 --output bacteria-100k-cf <(head -1 flist)                                                                                                       │
-cargo run --release -- index -k 51 -s 1000 --output bacteria-1k-cf (head -1000 flist)                                                                                                       │
-cargo run --release -- index -k 51 -s 1000 --output bacteria-1k-cf $(head -1000 flist)                                                                                                      │
-cargo run --release -- index -k 51 -s 1000 --output bacteria-10k-cf <(head -10000 flist)                                                                                                    │
-cargo run --release -- index -k 51 -s 1000 --output bacteria-100k-cf flist                                                                                                                  │
-cargo run --release -- index -k 51 -s 1000 --output bacteria-1k-cf-opts <(head -1000 flist)                                                                                                 │
-cargo run --release -- index -k 51 -s 1000 --output bacteria-100k-cf-opts flist 
+{EXEC} index -k 21 -s 1000 --output /scratch/analysis/rocksdb_metagenomes catalog_metagenomes
+{EXEC} index -k 21 -s 10000 --output /scratch/analysis/rocksdb_metagenomes2 <(cat catalog_metagenomes | head 1000)
+{EXEC} index -k 21 -s 1000 --output /scratch/analysis/rocksdb_metagenomes2 <(cat catalog_metagenomes | head -n 10)
+{EXEC} index -k 21 -s 10000 --output /scratch/analysis/rocksdb_metagenomes2 <(cat catalog_metagenomes | head -n 10)
+{EXEC} index -k 21 -s 10000 --output /scratch/analysis/rocksdb_metagenomes2 <(cat catalog_metagenomes | head -n 1000)
+{EXEC} index -k 51 -s 1000 --output bacteria-100k-enum flist
+{EXEC} index -k 51 -s 1000 --output bacteria-100k-cf <(head -1 flist)
+{EXEC} index -k 51 -s 1000 --output bacteria-1k-cf (head -1000 flist)
+{EXEC} index -k 51 -s 1000 --output bacteria-1k-cf $(head -1000 flist)
+{EXEC} index -k 51 -s 1000 --output bacteria-10k-cf <(head -10000 flist)
+{EXEC} index -k 51 -s 1000 --output bacteria-100k-cf flist
+{EXEC} index -k 51 -s 1000 --output bacteria-1k-cf-opts <(head -1000 flist)
+{EXEC} index -k 51 -s 1000 --output bacteria-100k-cf-opts flist
 """

--- a/experiments/Snakefile
+++ b/experiments/Snakefile
@@ -1,73 +1,62 @@
 EXEC="cargo run -p mastiff-index --release -- "
 
 rule all:
-    input: "outputs/bacteria-1k"
+#    input: "outputs/rs207"
+    input: "outputs/rs207-2k"
 
-rule bacteria_1k:
-    output: directory("outputs/bacteria-1k")
-    input: "inputs/gtdb-rs207.genomic-reps.dna.k21.manifest",
+rule rs207_1k:
+    output: directory("outputs/rs207-1k")
+    input:
+      storage="inputs/gtdb-rs207.genomic-reps.dna.k21.zip",
+      manifest="inputs/gtdb-rs207.genomic-reps.dna.k21.manifest"
     threads: 24
     shell: """
         export RAYON_NUM_THREADS={threads}
-        RUST_LOG=debug {EXEC} index -k 21 -s 1000 \
+        RUST_LOG=info {EXEC} index -k 21 -s 1000 \
           --output {output} \
-          <(head -1000 {input})
+          --manifest <(head -1002 {input.manifest}) \
+          {input.storage}
     """
 
-rule bacteria_2k:
-    output: directory("outputs/bacteria-2k")
+rule rs207_2k:
+    output: directory("outputs/rs207-2k")
     input: 
-        previous="outputs/bacteria-1k",
+        previous="outputs/rs207-1k",
+        storage="inputs/gtdb-rs207.genomic-reps.dna.k21.zip",
         manifest="inputs/gtdb-rs207.genomic-reps.dna.k21.manifest",
+    threads: 24
     shell: """
+        export RAYON_NUM_THREADS={threads}
         cp -a {input.previous} {output}
         {EXEC} update -k 21 -s 1000 \
           --output {output} \
-          <(head -2000 {input.manifest})
+          --manifest <(head -2002 {input.manifest}) \
+          {input.storage}
     """
 
-rule bacteria_1k_colors:
-    output: directory("outputs/bacteria-1k-colors")
+rule rs_207:
+    output: directory("outputs/rs207")
+    input: "inputs/gtdb-rs207.genomic-reps.dna.k21.zip"
     shell: """
-        RUST_LOG=debug {EXEC} index -k 51 -s 1000 --colors \
-          --output {output} \
-          <(head -1000 flist)
+        {EXEC} index -k 21 -s 1000 \
+            --output {output} \
+            {input}
     """
 
-rule bacteria_10k:
-    output: directory("outputs/bacteria-10k")
+rule download_rs_207:
+    output: "inputs/gtdb-rs207.genomic-reps.dna.k21.zip"
     shell: """
-        {EXEC} index -k 51 -s 1000 \
-          --output {output} \
-          <(head -10000 flist)
+        curl -L https://osf.io/download/f2wzc/ -o {output}
     """
 
-rule bacteria_10k_colors:
-    output: directory("outputs/bacteria-10k-colors")
+rule extract_rs_207_manifest:
+    output: "inputs/gtdb-rs207.genomic-reps.dna.k21.manifest"
+    input: "inputs/gtdb-rs207.genomic-reps.dna.k21.zip"
     shell: """
-        {EXEC} index -k 51 -s 1000 --colors \
-          --output {output} \
-          <(head -10000 flist)
+        unzip -p {input} SOURMASH-MANIFEST.csv > {output}
     """
 
-rule bacteria_fullcolors:
-    output: directory("outputs/bacteria-fullcolors")
-    shell: """
-        {EXEC} index -k 51 -s 1000 --colors \
-          --output {output} \
-          <(head -1 flist | xargs yes | head -1000)
-    """
-
-rule bacteria_k51_s1000:
-    output: directory("outputs/bacteria-k51-s1000")
-    benchmark:
-        "benchmarks/bacteria-k51-s1000.tsv"
-    shell: """
-        {EXEC} index -k 51 -s 1000 \
-          --output {output} \
-          flist_bacteria-k51
-    """
-
+#######################################################################
 
 #rule metag_all:
 #    output: directory("/scratch/analysis/metag_k21_s{scaled,\d+}-roaring")
@@ -118,33 +107,6 @@ rule metag_1k_colors:
             --colors \
             --save-paths \
             <(head -1000 catalog_metagenomes)
-    """
-
-rule download_rs_207:
-    output: "inputs/gtdb-rs207.genomic-reps.dna.k21.zip"
-    shell: """
-        curl -L https://osf.io/download/f2wzc/ -o {output}
-    """
-
-rule extract_rs_207:
-    output: 
-        manifest="inputs/gtdb-rs207.genomic-reps.dna.k21.manifest",
-        data=directory("inputs/gtdb-rs207.genomic-reps.dna.k21")
-    input: "inputs/gtdb-rs207.genomic-reps.dna.k21.zip"
-    shell: """
-        python -m zipfile -e {input} {output.data}
-        find `realpath {output.data}` -iname "*.sig.gz" > {output.manifest}
-    """
-
-rule rs_207:
-    output: directory("outputs/rs207")
-    input: 
-      manifest="inputs/gtdb-rs207.genomic-reps.dna.k21.manifest",
-      data=directory("inputs/gtdb-rs207.genomic-reps.dna.k21")
-    shell: """
-        RUST_LOG=trace {EXEC} index -k 21 -s 1000 \
-            --output {output} \
-            {input.manifest}
     """
 
 rule new_catalog:

--- a/experiments/Snakefile
+++ b/experiments/Snakefile
@@ -63,7 +63,7 @@ rule metag_100:
     output: directory("outputs/metag-100")
     input:
       storage="/data/wort/wort-sra",
-      manifest="inputs/metagenomes-k21-s1000-test.manifest"
+      manifest="outputs/metagenomes-k21-s1000.manifest",
     threads: 24
     shell: """
         export RAYON_NUM_THREADS={threads}
@@ -78,7 +78,7 @@ rule metag_200:
     input:
       previous="outputs/metag-100",
       storage="/data/wort/wort-sra",
-      manifest="inputs/metagenomes-k21-s1000-test.manifest"
+      manifest="outputs/metagenomes-k21-s1000.manifest",
     threads: 24
     shell: """
         export RAYON_NUM_THREADS={threads}
@@ -88,6 +88,22 @@ rule metag_200:
           --manifest <(head -202 {input.manifest}) \
           {input.storage}
     """
+
+rule metag:
+    output: directory("outputs/metag")
+    input:
+      storage="/data/wort/wort-sra",
+      manifest="outputs/metagenomes-k21-s1000.manifest",
+    threads: 24
+    shell: """
+        export RAYON_NUM_THREADS={threads}
+        RUST_LOG=info {EXEC} index -k 21 -s 1000 \
+          --output {output} \
+          --manifest {input.manifest} \
+          {input.storage}
+    """
+
+#######################################################################
 
 rule manifest_test:
     output:

--- a/experiments/Snakefile
+++ b/experiments/Snakefile
@@ -1,11 +1,17 @@
 EXEC="cargo run -p mastiff-index --release -- "
 
+rule all:
+    input: "outputs/bacteria-1k"
+
 rule bacteria_1k:
     output: directory("outputs/bacteria-1k")
+    input: "inputs/gtdb-rs207.genomic-reps.dna.k21.manifest",
+    threads: 24
     shell: """
-        {EXEC} index -k 51 -s 1000 \
+        export RAYON_NUM_THREADS={threads}
+        RUST_LOG=debug {EXEC} index -k 21 -s 1000 \
           --output {output} \
-          <(head -1000 flist)
+          <(head -1000 {input})
     """
 
 rule bacteria_1k_save_paths:

--- a/flake.lock
+++ b/flake.lock
@@ -14,11 +14,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693787605,
-        "narHash": "sha256-rwq5U8dy+a9JFny/73L0SJu1GfWwATMPMTp7D+mjHy8=",
+        "lastModified": 1695511445,
+        "narHash": "sha256-mnE14re43v3/Jc50Jv0BKPMtEk7FEtDSligP6B5HwlI=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "8b4f7a4dab2120cf41e7957a28a853f45016bd9d",
+        "rev": "3de322e06fc88ada5e3589dc8a375b73e749f512",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693780807,
-        "narHash": "sha256-diV1X53HjSB3fIcDFieh9tGZkJ3vqJJQhTz89NbYw60=",
+        "lastModified": 1695806987,
+        "narHash": "sha256-fX5kGs66NZIxCMcpAGIpxuftajHL8Hil1vjHmjjl118=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "84ef5335abf541d8148433489e0cf79affae3f89",
+        "rev": "f3dab3509afca932f3f4fd0908957709bb1c1f57",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693793487,
-        "narHash": "sha256-MS6CDyAC0sJMTE/pRYlfrhBnhlAPvEo43ipwf5ZNzHg=",
+        "lastModified": 1696039808,
+        "narHash": "sha256-7TbAr9LskWG6ISPhUdyp6zHboT7FsFrME5QsWKybPTA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f179280eed5eb93759c94bf3231fbbda28f894b7",
+        "rev": "a4c3c904ab29e04a20d3a6da6626d66030385773",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,44 +2,21 @@
   "nodes": {
     "crane": {
       "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": [
-          "flake-utils"
-        ],
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "rust-overlay": [
-          "rust-overlay"
         ]
       },
       "locked": {
-        "lastModified": 1695511445,
-        "narHash": "sha256-mnE14re43v3/Jc50Jv0BKPMtEk7FEtDSligP6B5HwlI=",
+        "lastModified": 1701622587,
+        "narHash": "sha256-o3XhxCCyrUHZ0tlta2W7/MuXzy+n0+BUt3rKFK3DIK4=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "3de322e06fc88ada5e3589dc8a375b73e749f512",
+        "rev": "c09d2cbe84cc2adfe1943cb2a0b55a71c835ca9a",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
         "repo": "crane",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
         "type": "github"
       }
     },
@@ -63,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1695806987,
-        "narHash": "sha256-fX5kGs66NZIxCMcpAGIpxuftajHL8Hil1vjHmjjl118=",
+        "lastModified": 1701432845,
+        "narHash": "sha256-06sd2rQ+DPMSueh+hW4MiXbpMSdhQHJOi/sw0vuwqvs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f3dab3509afca932f3f4fd0908957709bb1c1f57",
+        "rev": "77da99a144cd341408308e0a37622f5edcc6c5ba",
         "type": "github"
       },
       "original": {
@@ -95,11 +72,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696039808,
-        "narHash": "sha256-7TbAr9LskWG6ISPhUdyp6zHboT7FsFrME5QsWKybPTA=",
+        "lastModified": 1701569797,
+        "narHash": "sha256-ObvQFAPpC5IVbI2GHedSTQVzYxht2qhBgHHQnh3mYTs=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a4c3c904ab29e04a20d3a6da6626d66030385773",
+        "rev": "516c9477757b628b157780d96d84e8c82b46dc99",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -14,11 +14,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683505101,
-        "narHash": "sha256-VBU64Jfu2V4sUR5+tuQS9erBRAe/QEYUxdVMcJGMZZs=",
+        "lastModified": 1693787605,
+        "narHash": "sha256-rwq5U8dy+a9JFny/73L0SJu1GfWwATMPMTp7D+mjHy8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "7b5bd9e5acb2bb0cfba2d65f34d8568a894cdb6c",
+        "rev": "8b4f7a4dab2120cf41e7957a28a853f45016bd9d",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1683777345,
-        "narHash": "sha256-V2p/A4RpEGqEZussOnHYMU6XglxBJGCODdzoyvcwig8=",
+        "lastModified": 1693780807,
+        "narHash": "sha256-diV1X53HjSB3fIcDFieh9tGZkJ3vqJJQhTz89NbYw60=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "635a306fc8ede2e34cb3dd0d6d0a5d49362150ed",
+        "rev": "84ef5335abf541d8148433489e0cf79affae3f89",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683857898,
-        "narHash": "sha256-pyVY4UxM6zUX97g6bk6UyCbZGCWZb2Zykrne8YxacRA=",
+        "lastModified": 1693793487,
+        "narHash": "sha256-MS6CDyAC0sJMTE/pRYlfrhBnhlAPvEo43ipwf5ZNzHg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4e7fba3f37f5e184ada0ef3cf1e4d8ef450f240b",
+        "rev": "f179280eed5eb93759c94bf3231fbbda28f894b7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,8 +7,6 @@
     crane = {
       url = "github:ipetkov/crane";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.rust-overlay.follows = "rust-overlay";
-      inputs.flake-utils.follows = "flake-utils";
     };
 
     flake-utils.url = "github:numtide/flake-utils";
@@ -146,9 +144,8 @@
 
           buildInputs = with pkgs; [
               oha
-              awscli2
+              #awscli2
               rclone
-              terraform
               nixpkgs-fmt
               asciinema
               asciinema-agg

--- a/flake.nix
+++ b/flake.nix
@@ -155,6 +155,8 @@
 
               cargo-udeps
               cargo-outdated
+              cargo-watch
+              cargo-limit
 
               snakemake
               parallel-full

--- a/flake.nix
+++ b/flake.nix
@@ -155,6 +155,9 @@
 
               cargo-udeps
               cargo-outdated
+
+              snakemake
+              parallel-full
           ];
         });
       });


### PR DESCRIPTION
[rocksdb-eval](https://github.com/luizirber/2022-06-26-rocksdb-eval) is the mastiff PoC, and since https://github.com/sourmash-bio/sourmash/pull/2230 inherited the sourmash parts (the Index implementation) it makes sense to move some operational tools (like `index`, `update`,`check`, and `convert`) here and archive the repo.